### PR TITLE
Fix a test error message assertion

### DIFF
--- a/packages/item-cc/tests/item.spec.ts
+++ b/packages/item-cc/tests/item.spec.ts
@@ -145,7 +145,7 @@ describe('Item', () => {
     const itemQuality = "Good";
     const materials = "mockMaterial1, mockMaterial2";
 
-    expect(itemCtrl.create(itemName, ownerID, itemQuality, materials).catch(e => e.responses[0].error.message)).to.be.eventually.eql('Given participant as owner does not currently exist on the ledger');
+    expect(itemCtrl.create(itemName, ownerID, itemQuality, materials).catch(e => e.responses[0].error.message)).to.be.eventually.eql('Given participant is not a participant, and therefore is not allowed to perform this action.');
   });
 
   // Test for create item


### PR DESCRIPTION
All tests were passing, but an assertion of the exact error message was wrong. Fixed that.